### PR TITLE
Add flake8 plugins

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,31 @@ python =
 max-line-length = 120
 max-complexity = 10
 
+# B9: Bugbear opinionated
+extend-select = B902, B903, B904, B907, B950
+
+# A003: class attribute shadowing builtin
+#       Pedantic; attribute access is qualified, so it won't actually shadow
 # E203: Black style
-extend-ignore = E203
+# E501: Using B950 instead
+# E722, PIE786: Redundant with B001
+# PIE789, PIE791: Redundant with E721 and B015/B018 respectively
+# R504: Tends to give a lot of false-positives; PIE781 works better
+extend-ignore = A003, E203, E501, R504, PIE786, PIE789, PIE791
+
+# B011, S101: Asserts are normal in tests
+per-file-ignores =
+    test_*.py: B011, S101
+
+[flake8-plugins]
+deps =
+    flake8-bandit
+    flake8-breakpoint
+    flake8-bugbear
+    flake8-builtins
+    flake8-comprehensions
+    flake8-pie
+    flake8-return
 
 [testenv]
 deps = pytest
@@ -25,6 +48,7 @@ ignore_errors = true
 deps =
     black
     flake8
+    {[flake8-plugins]deps}
     isort
 commands =
     flake8 {posargs:src tests}
@@ -46,5 +70,7 @@ commands = python -m build --no-isolation {posargs}
 
 [testenv:dev]
 description = Set up development environment; use as a target for `tox devenv`
+deps =
+    {[flake8-plugins]deps}
 use_develop = true
 extras = dev


### PR DESCRIPTION
Since we're using flake8 for linting, we should take advantage of flake8's pluggable design and include some popular extra lints to help ensure code quality going forward. There are a ton of plugins out there, but I opted for ones that are the most generally useful and ones that I've personally used before.

I keep note of which lints I explicitly include/exclude and why in comments where they're included/excluded. Following usual practices, I kept the default flake8 suite of lints enabled and selectively include/exclude lints with the `extend-` options.

If there's any lints that you'd rather not have, or know of others that you'd like included, feel free to let me know! I'm plenty open to what lints we use/don't use.

### RFC

Depending on how you feel about the rationale regarding the interpolation in `logging` messages, we could keep or disable [PIE803](https://github.com/sbdchd/flake8-pie#pie803-prefer-logging-interpolation). I could go either way, but I think the concerns matter more for library code and much less for applications.